### PR TITLE
Update: Remove Custom Migration

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/spprichard/MLBScrapperLib.git",
         "state": {
           "branch": null,
-          "revision": "ecf713b2b1697c64b892e9fad227b8d6fe25c1e5",
-          "version": "0.0.5"
+          "revision": "1fb886d65f9ed17b0e4feea3755c268856b5635d",
+          "version": "0.0.8"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),
 
         // 📚 A library for working with the MLB Lookup Service
-        .package(url: "https://github.com/spprichard/MLBScrapperLib.git", from:"0.0.5"),
+        .package(url: "https://github.com/spprichard/MLBScrapperLib.git", from:"0.0.8"),
         
         // 🏬 A package for working with a Postgress Database
         .package(url: "https://github.com/vapor/fluent-postgresql.git", from: "1.0.0"),

--- a/Sources/App/Models/Extensions.swift
+++ b/Sources/App/Models/Extensions.swift
@@ -13,19 +13,4 @@ import MLBScrapperLib
 extension Team: PostgreSQLModel {}
 extension Team: Migration {}
 extension Team: Content {}
-
-extension Team: PostgreSQLMigration {
-    public static func prepare(on conn: PostgreSQLConnection) -> EventLoopFuture<Void> {
-        return PostgreSQLDatabase.create(Team.self, on: conn) { builder in
-            builder.field(for: \.id, isIdentifier: true)
-            builder.field(for: \.VenueID)
-            builder.field(for: \.VenueName)
-            builder.field(for: \.Name)
-            builder.field(for: \.DivisionID)
-        }
-    }
-    
-    public static func revert(on connection: PostgreSQLConnection) -> EventLoopFuture<Void> {
-        return PostgreSQLDatabase.delete(Team.self, on: connection)
-    }
-}
+extension Team: Model {}


### PR DESCRIPTION
- Remove migration
- Migration not needed with new version of Lib
- Use of MLBLookupTeam allows for Team type to not need a custom migration